### PR TITLE
refactor: Add i18n support for multiple languages

### DIFF
--- a/src/components/change-language/index.tsx
+++ b/src/components/change-language/index.tsx
@@ -8,7 +8,7 @@ import './image-language.css';
 export type Languages = 'pt-BR' | 'en-US';
 
 export default function I18n() {
-  const { i18n } = useTranslation();
+  const { i18n, t } = useTranslation();
 
   function handleChangeLanguage(language: Languages) {
     i18n.changeLanguage(language);
@@ -22,13 +22,13 @@ export default function I18n() {
         image={FlagBrazil}
         isSelected={selectedLanguage === 'pt-BR'}
         onChangeLanguage={() => handleChangeLanguage('pt-BR')}
-        altText="Brazil Flag"
+        altText={t('alt_image.flag_brazil')}
       />
       <ImageLanguage
         image={FlagEUA}
         isSelected={selectedLanguage === 'en-US'}
         onChangeLanguage={() => handleChangeLanguage('en-US')}
-        altText="USA Flag"
+        altText={t('alt_image.flag_united_states')}
       />
     </>
   );

--- a/src/components/qualification/education/index.tsx
+++ b/src/components/qualification/education/index.tsx
@@ -1,19 +1,25 @@
 import { CalendarDays } from 'lucide-react';
+import Translator from '../../../hooks/use-translator';
+import { ReactNode } from 'react';
 
 interface QualificationEducationProps {
-  course: string;
+  course: ReactNode;
   locality: string;
   time: string;
 }
 
 const qualificationEducations: QualificationEducationProps[] = [
   {
-    course: 'Assistente de desenvolvimento de aplicativos computacionais',
+    course: (
+      <Translator path="education.assistente_de_desenvolvimento_de_aplicativos_computacionais" />
+    ),
     locality: 'Senac Lapa Tito - SP',
     time: '2019 - 2020',
   },
   {
-    course: 'Assistente de operação de redes de computadores',
+    course: (
+      <Translator path="education.assistente_de_operacao_de_redes_de_computadores" />
+    ),
     locality: 'Senac Lapa Tito - SP',
     time: '2018 - 2019',
   },

--- a/src/components/qualification/experiences/index.tsx
+++ b/src/components/qualification/experiences/index.tsx
@@ -1,4 +1,6 @@
 import { CalendarDays } from 'lucide-react';
+import Translator from '../../../hooks/use-translator';
+import { ReactNode } from 'react';
 
 type QualificationExperienceCompanyName =
   | 'Luby'
@@ -8,30 +10,30 @@ type QualificationExperienceCompanyName =
 
 interface QualificationExperiencesProps {
   company: QualificationExperienceCompanyName;
-  charger: string;
+  charger: ReactNode;
   time: string;
 }
 
 const qualificationExperiences: QualificationExperiencesProps[] = [
   {
     company: 'Luby',
-    charger: 'Programador Júnior',
+    charger: <Translator path="experiences.junior_developer" />,
     time: 'Ago 2019 - Jul 2020',
   },
   {
     company: '4you2 idiomas',
-    charger: 'Programador Júnior',
+    charger: <Translator path="experiences.junior_developer" />,
     time: 'Set 2020 - Jan 2021',
   },
   {
     company: 'Zapsign',
-    charger: 'Desenvolvedor Full-Stack Pleno',
+    charger: <Translator path="experiences.pleno_full_stack_developer" />,
     time: 'Dez 2020 - Jan 2024',
   },
   {
     company: 'Nan Systems',
-    charger: 'Desenvolvedor Full-Stack Pleno',
-    time: 'Fev 2024 - atual',
+    charger: <Translator path="experiences.pleno_full_stack_developer" />,
+    time: `Fev 2024 - atual`,
   },
 ];
 

--- a/src/components/qualification/index.tsx
+++ b/src/components/qualification/index.tsx
@@ -3,6 +3,7 @@ import Tab, { tabs, TabsVariants } from './tabs';
 import Education from './education';
 import QualificationExperience from './experiences';
 import './qualification.css';
+import Translator from '../../hooks/use-translator';
 
 function Qualification() {
   const [activeTab, setActiveTab] = useState<TabsVariants>('experience');
@@ -13,8 +14,12 @@ function Qualification() {
 
   return (
     <section className="qualification section" id="qualification">
-      <h2 className="section__title">Qualificação</h2>
-      <span className="section__subtitle">Minha jornada profissional</span>
+      <h2 className="section__title">
+        <Translator path="qualification.title" />
+      </h2>
+      <span className="section__subtitle">
+        <Translator path="qualification.subtitle" />
+      </span>
 
       <div className="qualification__container container">
         <div className="qualification__tabs">

--- a/src/components/qualification/tabs/index.tsx
+++ b/src/components/qualification/tabs/index.tsx
@@ -1,24 +1,25 @@
 import { BriefcaseBusiness, GraduationCap } from 'lucide-react';
 import { ReactNode } from 'react';
+import Translator from '../../../hooks/use-translator';
 
 export type TabsVariants = 'education' | 'experience';
 
 interface TabsProps {
   id: TabsVariants;
   icon: ReactNode;
-  title: string;
+  title: ReactNode;
 }
 
 export const tabs: TabsProps[] = [
   {
     id: 'experience',
     icon: <BriefcaseBusiness />,
-    title: 'Experiência',
+    title: <Translator path="tabs.experience" />,
   },
   {
     id: 'education',
     icon: <GraduationCap />,
-    title: 'Educação',
+    title: <Translator path="tabs.education" />,
   },
 ];
 

--- a/src/components/skills/Backend.tsx
+++ b/src/components/skills/Backend.tsx
@@ -1,18 +1,20 @@
 import { BadgeCheck } from 'lucide-react';
 import { SkillsProps } from '.';
+import Translator from '../../hooks/use-translator';
+import { ReactNode } from 'react';
 
 type BackendNameSkills = 'Python' | 'Django' | 'Postgres' | 'Vercel';
 
 interface BackendSkills extends SkillsProps<BackendNameSkills> {
   name: BackendNameSkills;
-  level: string;
+  level: ReactNode;
 }
 
 const tools: BackendSkills[] = [
-  { name: 'Python', level: '3 anos' },
-  { name: 'Django', level: '3 anos' },
-  { name: 'Postgres', level: '2 anos' },
-  { name: 'Vercel', level: '7 meses' },
+  { name: 'Python', level: <Translator path="tools.three_years_of_use" /> },
+  { name: 'Django', level: <Translator path="tools.three_years_of_use" /> },
+  { name: 'Postgres', level: <Translator path="tools.two_years_of_use" /> },
+  { name: 'Vercel', level: <Translator path="tools.seven_months_of_use" /> },
 ];
 
 export default function Backend() {

--- a/src/components/skills/Frontend.tsx
+++ b/src/components/skills/Frontend.tsx
@@ -1,5 +1,7 @@
 import { BadgeCheck } from 'lucide-react';
 import { SkillsProps } from '.';
+import Translator from '../../hooks/use-translator';
+import { ReactNode } from 'react';
 
 type FrontendNameSkills =
   | 'HTML'
@@ -14,18 +16,18 @@ type FrontendNameSkills =
 
 interface FrontendSkills extends SkillsProps<FrontendNameSkills> {
   name: FrontendNameSkills;
-  level: string;
+  level: ReactNode;
 }
 
 const tools: FrontendSkills[] = [
-  { name: 'HTML', level: '4 anos de uso' },
-  { name: 'CSS', level: '4 anos de uso' },
-  { name: 'Sass', level: '3 anos de uso' },
-  { name: 'Bootstrap', level: '3 anos de uso' },
-  { name: 'Typescript', level: '2 anos de uso' },
-  { name: 'Angular 9', level: '3 anos de uso' },
-  { name: 'React', level: '3 anos de uso' },
-  { name: 'Redux', level: '1 ano de uso' },
+  { name: 'HTML', level: <Translator path="tools.four_years_of_use" /> },
+  { name: 'CSS', level: <Translator path="tools.four_years_of_use" /> },
+  { name: 'Sass', level: <Translator path="tools.two_years_of_use" /> },
+  { name: 'Bootstrap', level: <Translator path="tools.two_years_of_use" /> },
+  { name: 'Typescript', level: <Translator path="tools.two_years_of_use" /> },
+  { name: 'Angular 9', level: <Translator path="tools.two_years_of_use" /> },
+  { name: 'React', level: <Translator path="tools.two_years_of_use" /> },
+  { name: 'Redux', level: <Translator path="tools.one_year_of_use" /> },
 ];
 
 export default function Frontend() {

--- a/src/components/skills/Tests.tsx
+++ b/src/components/skills/Tests.tsx
@@ -1,25 +1,29 @@
 import { BookOpenText } from 'lucide-react';
 import { SkillsProps } from '.';
+import Translator from '../../hooks/use-translator';
+import { ReactNode } from 'react';
 
 type ToolsSkills = 'pytest' | 'unittest' | 'cypress' | 'jest' | 'vitest';
 
 interface Tools extends SkillsProps<ToolsSkills> {
   name: ToolsSkills;
-  level: string;
+  level: ReactNode;
 }
 
 const tools: Tools[] = [
-  { name: 'pytest', level: '2 anos de uso' },
-  { name: 'unittest', level: '2 anos de uso' },
-  { name: 'cypress', level: '1 ano de uso' },
-  { name: 'jest', level: '2 anos de uso' },
-  { name: 'vitest', level: '1 ano de uso' },
+  { name: 'pytest', level: <Translator path="tools.two_years_of_use" /> },
+  { name: 'unittest', level: <Translator path="tools.two_years_of_use" /> },
+  { name: 'cypress', level: <Translator path="tools.one_year_of_use" /> },
+  { name: 'jest', level: <Translator path="tools.two_years_of_use" /> },
+  { name: 'vitest', level: <Translator path="tools.one_year_of_use" /> },
 ];
 
 export default function Tests() {
   return (
     <div className="skills__content">
-      <h3 className="skills__title">Testes</h3>
+      <h3 className="skills__title">
+        <Translator path="tests.title" />
+      </h3>
       <div className="skills__box">
         <div className="skills__group">
           {tools.map(({ name, level }) => (

--- a/src/components/skills/Tools.tsx
+++ b/src/components/skills/Tools.tsx
@@ -1,3 +1,5 @@
+import Translator from '../../hooks/use-translator';
+
 type ToolsSkillsName =
   | 'npm & yarn'
   | 'postman'
@@ -50,7 +52,9 @@ const tools: ToolsSkills[] = [
 export default function Tools() {
   return (
     <div className="skills__content">
-      <h3 className="skills__title">Ferramentas do dia a dia</h3>
+      <h3 className="skills__title">
+        <Translator path="tools.tools_day_by_day" />
+      </h3>
       <div className="skills__box">
         <div className="skills__group">
           {tools.map(({ name }) => (

--- a/src/components/skills/index.tsx
+++ b/src/components/skills/index.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+import Translator from '../../hooks/use-translator';
 import Backend from './Backend';
 import Frontend from './Frontend';
 import './skills.css';
@@ -6,14 +8,16 @@ import Tools from './Tools';
 
 export interface SkillsProps<T> {
   name: T;
-  level: string;
+  level: string | ReactNode;
 }
 
 export default function Skills() {
   return (
     <section className="skills" id="skills">
       <h2 className="section__title">Skills</h2>
-      <span className="section__subtitle">My nível técnico em programação</span>
+      <span className="section__subtitle">
+        <Translator path="home.skills_subtitle" />
+      </span>
       <div className="skills__container container grid">
         <Frontend />
         <Backend />

--- a/src/i18n/locales/en-us.ts
+++ b/src/i18n/locales/en-us.ts
@@ -18,6 +18,42 @@ export default {
       years_as_developer: '4 years as a developer',
       quantity_projects_completed: '+16 projects completed',
       how_i_work: 'Remote and in person',
+      skills_subtitle: 'My technical level in programming',
+    },
+    tests: {
+      title: 'Tests',
+    },
+    tools: {
+      tools_day_by_day: 'Tools day by day',
+      four_years_of_use: '4 years of use',
+      three_years_of_use: '3 years of use',
+      two_years_of_use: '2 years of use',
+      one_year_of_use: '1 year of use',
+      seven_months_of_use: '7 months',
+    },
+    education: {
+      assistente_de_desenvolvimento_de_aplicativos_computacionais:
+        'Computational application development assistant',
+      assistente_de_operacao_de_redes_de_computadores:
+        'Computer network operation assistant',
+    },
+    experiences: {
+      junior_developer: 'Junior Developer',
+      pleno_full_stack_developer: 'Middle Full Stack Developer',
+      actual: 'Now',
+    },
+    qualification: {
+      title: 'Qualification',
+      subtitle: 'My professional journey',
+    },
+    tabs: {
+      experience: 'Experience',
+      education: 'Education',
+    },
+
+    alt_image: {
+      flag_brazil: 'Brazil flag',
+      flag_united_states: 'United States flag',
     },
   },
 };

--- a/src/i18n/locales/pt-br.ts
+++ b/src/i18n/locales/pt-br.ts
@@ -19,6 +19,44 @@ export default {
       years_as_developer: '4 anos como desenvolvedor',
       quantity_projects_completed: '+16 projetos concluídos',
       how_i_work: 'Remoto e presencial',
+      skills_subtitle: 'Meu nível técnico em programação',
+    },
+    tests: {
+      title: 'Testes',
+    },
+    tools: {
+      tools_day_by_day: 'Ferramentas do dia a dia',
+      four_years_of_use: '4 anos de uso',
+      three_years_of_use: '3 anos de uso',
+      two_years_of_use: '2 anos de uso',
+      one_year_of_use: '1 ano de uso',
+      seven_months_of_use: '7 meses',
+    },
+    education: {
+      assistente_de_desenvolvimento_de_aplicativos_computacionais:
+        'Assistente de desenvolvimento de aplicativos computacionais',
+      assistente_de_operacao_de_redes_de_computadores:
+        'Assistente de operação de redes de computadores',
+    },
+    experiences: {
+      junior_developer: 'Programador Júnior',
+      pleno_full_stack_developer: 'Desenvolvedor Full-Stack Pleno',
+      actual: 'Atual',
+    },
+    qualification: {
+      title: 'Qualificação',
+      subtitle: 'Minha jornada profissional',
+    },
+    tabs: {
+      experience: 'Experiência',
+      education: 'Educação',
+    },
+
+    // Accesibility
+
+    alt_image: {
+      flag_brazil: 'Bandeira do Brasil',
+      flag_united_states: 'Bandeira dos Estados Unidos',
     },
   },
 };


### PR DESCRIPTION
- Import Translator component in Tools.tsx, index.tsx, change-language/index.tsx, and education/index.tsx

- Replace hardcoded strings with translated strings using the Translator component in Tools.tsx, index.tsx, change-language/index.tsx, and education/index.tsx

- Update the title prop in tabs/index.tsx and qualification/index.tsx to use the Translator component for translation

- Update the course prop in education/index.tsx to use the Translator component for translation

- Update the charger prop in experiences/index.tsx to use the Translator component for translation

- Update the subtitle prop in index.tsx and skills/index.tsx to use the Translator component for translation

- Update the altText prop in change-language/index.tsx to use the Translator component for translation

- Update the level prop in Backend.tsx to use the Translator component for translation